### PR TITLE
manifest: track our own packages/apps/Exchange

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -360,6 +360,7 @@
   <project path="packages/apps/DSPManager" name="android_packages_apps_DSPManager" remote="omnirom" revision="android-6.0" />
   <project path="packages/apps/Email" name="android_packages_apps_Email" remote="omnirom" revision="android-6.0" />
   <project path="packages/apps/ExactCalculator" name="platform/packages/apps/ExactCalculator" groups="pdk-fs" />
+  <project path="packages/apps/Exchange" name="android_packages_apps_Exchange" remote="omnirom" revision="android-6.0" />
   <project path="packages/apps/FMRadio" name="platform/packages/apps/FMRadio" />
   <project path="packages/apps/Gallery2" name="android_packages_apps_Gallery2" remote="omnirom" revision="android-6.0" />
   <project path="packages/apps/HTMLViewer" name="platform/packages/apps/HTMLViewer" />


### PR DESCRIPTION
- legacy reasons: Exchange does not exist in r22; track r17

Change-Id: I713ac4e5840ea1208caa8d486b06e9e4ba125d3b